### PR TITLE
InputPackage extends RefCounted

### DIFF
--- a/Enemies/Humanoid/Enemy.gd
+++ b/Enemies/Humanoid/Enemy.gd
@@ -18,4 +18,3 @@ func _physics_process(delta):
 	
 	# Visuals -> follow parent transformations
 	
-	input.queue_free()

--- a/Player/Input/InputPackage.gd
+++ b/Player/Input/InputPackage.gd
@@ -1,4 +1,4 @@
-extends Node
+extends RefCounted
 class_name InputPackage
 
 var actions : Array[String]

--- a/Player/Player.gd
+++ b/Player/Player.gd
@@ -18,4 +18,3 @@ func _physics_process(delta):
 	var input = input_gatherer.gather_input()
 	model.update(input, delta)
 	# Visuals -> follow parent transformations
-	input.queue_free()


### PR DESCRIPTION
Recommended type change for InputPackage to not be Node but RefCounted. No extra baggage from Node type and don't need to be manually freed.

Base class for any object that keeps a reference count. Resource and many other helper objects inherit this class.
Unlike other Object types, RefCounteds keep an internal reference counter so that they are automatically released when no longer in use, and only then. RefCounteds therefore do not need to be freed manually with Object.free().
