### PR TITLE
Make sure first state is _on_enter_state() is called

### DIFF
--- a/Player/HumanoidModel/Model.gd
+++ b/Player/HumanoidModel/Model.gd
@@ -28,6 +28,7 @@ func _ready():
 	moves_container.player = player
 	moves_container.accept_moves()
 	current_move = moves_container.moves["idle"]
+	switch_to("idle")
 	legs.current_legs_move = moves_container.get_move_by_name("idle")
 	legs.accept_behaviours()
 


### PR DESCRIPTION
Without this, the idle state is not initialized properly. It works without it since it tends to transition to "midair" in the beginning, but could be important or cause some unintended bugs without it